### PR TITLE
Update Gradle wrapper from 4.6 to 4.10 to avoid errors with Java >=10

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.6-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.10-all.zip


### PR DESCRIPTION
* Local error fixed: "Could not determine java version from '10.0.1'[MAC OSX High Sierra]"
* TravisCI error fixed: https://travis-ci.com/CodelyTV/java-bootstrap/builds/91748800
* More info: https://github.com/gradle/gradle/issues/5764