### PR TITLE
Run the TravisCI build on OSX

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ jdk:
 
 os:
   - linux
+  - osx
 
 before_cache:
   - rm -f  $HOME/.gradle/caches/modules-2/modules-2.lock
@@ -16,6 +17,11 @@ cache:
   directories:
     - $HOME/.gradle/caches/
     - $HOME/.gradle/wrapper/
+
+# Run commands before TravisCI install step only in some cases
+# More info: https://docs.travis-ci.com/user/multi-os/#example-multi-os-build-matrix
+before_install:
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update; fi
 
 # Override default install process on TravisCI
 # Avoid default `gradlew assemble` execution. Be explicit about it on the `script` section.

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,5 +31,5 @@ install: true
 # Build pipeline
 # Compile before running the tests in order to easily check which task could be failing.
 script:
-  - ./gradlew assemble
-  - ./gradlew check
+  - ./gradlew assemble --warning-mode all
+  - ./gradlew check --warning-mode all


### PR DESCRIPTION
* Run the TravisCI build not only on Linux but also on OSX in order to illustrate the build matrix concept
* Add `--warning-mode all` in TravisCI steps
    * Why: "Deprecated Gradle features were used in this build, making it incompatible with Gradle 5.0. Use '--warning-mode all' to show the individual deprecation warnings."
    * More info: https://travis-ci.com/CodelyTV/java-bootstrap/jobs/159273540