### PR TITLE
docs(readme): provide installation link for corretto8

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ This is a repository intended to serve as a starting point if you want to bootst
 
 ## 🏁 How To Start
 
-1. Install Java 8: `brew cask install corretto8`
+1. Install Java 8: `brew cask install corretto8` or download it [here](https://docs.aws.amazon.com/corretto/latest/corretto-8-ug/downloads-list.html)
 2. Set it as your default JVM: `export JAVA_HOME='/Library/Java/JavaVirtualMachines/amazon-corretto-8.jdk/Contents/Home'`
 3. Clone this repository: `git clone https://github.com/CodelyTV/java-basic-skeleton`.
 4. Execute some [Gradle lifecycle tasks](https://docs.gradle.org/current/userguide/java_plugin.html#lifecycle_tasks) in order to check everything is OK:


### PR DESCRIPTION
#### Problem

Seems that there is not a `corretto8` available cask...
```
java-basic-skeleton ⚡️ brew cask install corretto8
Error: Cask 'corretto8' is unavailable: No Cask with this name exists.
```

#### Solution

Download it from [AWS docs](https://docs.aws.amazon.com/corretto/latest/corretto-8-ug/downloads-list.html)